### PR TITLE
chore(release): 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,28 @@ This changelog is automatically generated using
 [Conventional Commits](https://www.conventionalcommits.org/).
 
 View [unreleased changes][unreleased] since the last release.
+
+## [0.1.0] <a name="0.1.0" href="#0.1.0">-</a> January 28, 2026
+
+### 🚀 Features
+
+- Add config-time template expansion with environment variable support (#7) by
+  [@jmlopez-rod](https://github.com/jmlopez-rod) in
+  [#7](https://github.com/hotdog-werx/toolbelt/pull/7)
+
+### ⚙️ Miscellaneous Tasks
+
+- Adopt repolish (#6) by [@jmlopez-rod](https://github.com/jmlopez-rod) in
+  [#6](https://github.com/hotdog-werx/toolbelt/pull/6)
+
+[0.1.0]: https://github.com/hotdog-werx/toolbelt/compare/0.0.3...0.1.0
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is automatically generated using
+[git-cliff](https://git-cliff.org/) from commit messages following
+[Conventional Commits](https://www.conventionalcommits.org/).
+
+View [unreleased changes][unreleased] since the last release.


### PR DESCRIPTION
## [0.1.0] <a name="0.1.0" href="#0.1.0">-</a> January 28, 2026
### 🚀 Features
- Add config-time template expansion with environment variable support (#7) by [@jmlopez-rod](https://github.com/jmlopez-rod) in [#7](https://github.com/hotdog-werx/toolbelt/pull/7)
### ⚙️ Miscellaneous Tasks
- Adopt repolish (#6) by [@jmlopez-rod](https://github.com/jmlopez-rod) in [#6](https://github.com/hotdog-werx/toolbelt/pull/6)

[0.1.0]: https://github.com/hotdog-werx/toolbelt/compare/0.0.3...0.1.0
